### PR TITLE
Added custom modal boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,11 @@
 	<div id="modal-container">
 		<div id="modal-overlay"></div>
 		<div id="modal-box">
-			<h1 id="modal-title">Test title</h1>
-			<p id="modal-content"> Some test content  Some test content Some test content Some test content Some test content Some test content Some test content Some test content</p>
+			<h1 id="modal-title"></h1>
+			<p id="modal-content"></p>
 			<div id="modal-actions">
-				<button id="modal-cancel">Cancel</button>
-				<button id="modal-confirm">Confirm</button>
+				<button id="modal-cancel"></button>
+				<button id="modal-confirm"></button>
 			</div>
 		</div>
 	</div>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,17 @@
 			</div>
 		</div>
 	</template>
+	<div id="modal-container">
+		<div id="modal-overlay"></div>
+		<div id="modal-box">
+			<h1 id="modal-title">Test title</h1>
+			<p id="modal-content"> Some test content  Some test content Some test content Some test content Some test content Some test content Some test content Some test content</p>
+			<div id="modal-actions">
+				<button id="modal-cancel">Cancel</button>
+				<button id="modal-confirm">Confirm</button>
+			</div>
+		</div>
+	</div>
 </body>
 </html>
         

--- a/modal.js
+++ b/modal.js
@@ -1,0 +1,88 @@
+const elements = {
+    container: document.getElementById("modal-container"),
+    overlay: document.getElementById("modal-overlay"),
+    box: document.getElementById("modal-box"),
+    title: document.getElementById("modal-title"),
+    content: document.getElementById("modal-content"),
+    cancelbtn: document.getElementById("modal-cancel"),
+    confirmbtn: document.getElementById("modal-confirm"),
+};
+
+var callbacks = {
+    onCancel: null,
+    onConfirm: null,
+};
+
+// Function called when 'confirm' button is clicked
+function defaultConfirmCallback() {
+    closeModal();
+    typeof callbacks.onConfirm === "function" && callbacks.onConfirm();
+}
+
+// Function called when 'cancel' button is clicked
+function defaultCancelCallback() {
+    closeModal();
+    typeof callbacks.onCancel === "function" && callbacks.onCancel();
+}
+
+// Function to show the modal
+function showModal(title, content, options) {
+    console.log('called')
+    // Load the default options
+    options = {
+        cancelBtnText: "Cancel",
+        confirmBtnText: "Confirm",
+        showCancelBtn: true,
+        showConfirmBtn: true,
+        onCancel: null,
+        onConfirm: null,
+        ...options,
+    };
+    // Make the modal visible
+    elements.container.style.display = 'block'
+    elements.container.classList.add("visible");
+    elements.container.classList.remove("hidden");
+
+    // Manipulate the content
+    elements.title.innerText = title;
+    elements.content.innerText = content;
+    elements.cancelbtn.innerText = options.cancelBtnText;
+    elements.confirmbtn.innerText = options.confirmBtnText;
+
+    // To show or not to show the buttons
+    elements.cancelbtn.style.display = options.showCancelBtn ? "block" : "none";
+    elements.confirmbtn.style.display = options.showConfirmBtn
+        ? "block"
+        : "none";
+
+    // Add event listeners
+    callbacks = { onCancel: options.onCancel, onConfirm: options.onConfirm };
+}
+
+// Function to close the modal
+function closeModal() {
+    elements.container.classList.add("hidden");
+    elements.container.classList.remove("visible");
+}
+
+// Adds appropriate callbacks
+elements.overlay.addEventListener("click", defaultCancelCallback);
+elements.cancelbtn.addEventListener("click", defaultCancelCallback);
+elements.confirmbtn.addEventListener("click", defaultConfirmCallback);
+
+// Required for the display of the modal container to be none after the animation ends
+// Otherwise the container will still be there in the forefront of the webpage above
+// all other elements, which will cause issues with functionality as all clicks will
+// be taken by this element rather than the desired one
+elements.container.addEventListener('animationend', () => {
+
+    // Set the display to none only if the state is hidden because
+    // this event will also get fired when the fadein animation ends. 
+    if(elements.container.classList.contains('hidden')){
+        elements.container.style.display = 'none'
+    }
+})
+
+window.modal = showModal;
+
+export default { show: showModal };

--- a/modal.js
+++ b/modal.js
@@ -27,7 +27,6 @@ function defaultCancelCallback() {
 
 // Function to show the modal
 function showModal(title, content, options) {
-    console.log('called')
     // Load the default options
     options = {
         cancelBtnText: "Cancel",
@@ -82,7 +81,5 @@ elements.container.addEventListener('animationend', () => {
         elements.container.style.display = 'none'
     }
 })
-
-window.modal = showModal;
 
 export default { show: showModal };

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 import { getAuthor, getInstructions, getShuffledDeck } from "./decks.js"
+import modal from "./modal.js";
 
 let cardObjectsDeck = []
 
@@ -135,11 +136,18 @@ function flip()
 	{
 		this.classList.toggle("flipped");
 	}
-	else if(!cardObject.seenHint && confirm("Are you sure you want to see a hint?"))
+	else if(!cardObject.seenHint)
 	{
-		updateHintElement(++hintCount);
-		cardObject.seenHint = true;
-		this.classList.toggle("flipped");
+		modal.show("Hint Confirmation", "Are you sure you want to see a hint?", {
+			cancelBtnText: "No",
+			confirmBtnText: "Yes",
+			onConfirm : () => {
+				console.log("called")
+				updateHintElement(++hintCount);
+				cardObject.seenHint = true;
+				this.classList.toggle("flipped");
+			}
+		})
 	}
 }
 
@@ -269,14 +277,16 @@ function isDestinationFull()
 function showGameOver(won)
 {
 	const msg = won? `🏆    You won!    🏆`: `😭    You lost!    😭`;
-	if(confirm(`${msg}
-
-Your score is ${scoreCount} and you took ${hintCount} hint${hintCount===1?"":"s"}.
-
-${won? getAchievement() : ""}Select ok to play again!`))
-	{
-		location.reload();
-	}
+	modal.show(
+		msg,
+		`Your score is ${scoreCount} and you took ${hintCount} hint${hintCount===1?"":"s"}.
+${won? getAchievement() : ""}Select ok to play again!`,
+		{
+			showCancelBtn: false,
+			confirmBtnText: "OK",
+			onConfirm: () => window.location.reload()
+		}
+	)
 }
 
 function getAchievement()

--- a/script.js
+++ b/script.js
@@ -142,7 +142,6 @@ function flip()
 			cancelBtnText: "No",
 			confirmBtnText: "Yes",
 			onConfirm : () => {
-				console.log("called")
 				updateHintElement(++hintCount);
 				cardObject.seenHint = true;
 				this.classList.toggle("flipped");

--- a/styles.css
+++ b/styles.css
@@ -430,7 +430,7 @@ Display will be set to none for the hidden state using javascript.
 
 @keyframes modal-fadeout {
 	0% { opacity: 1; }
-	100% { opacity: 0;display: none !important; }
+	100% { opacity: 0; }
 }
 
 #modal-overlay {

--- a/styles.css
+++ b/styles.css
@@ -394,3 +394,96 @@ main{
 	border-color: hsl(120, 100%, 25%);
 	opacity: 1;
 }
+
+/*
+Excluding the container in its hidden state from this rule might appear
+counter-intuitive, but it is required for the animation to work correctly.
+Display will be set to none for the hidden state using javascript.
+*/
+#modal-container:not(.hidden) {
+	opacity: 0;
+	display: none;
+}
+
+#modal-container, #modal-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+	z-index: 1000;
+}
+
+#modal-container.visible {
+	display: block;
+	animation: modal-fadein 300ms ease-out 1 forwards;
+}
+
+#modal-container.hidden {
+	animation: modal-fadeout 300ms ease-out 1 forwards;
+}
+
+@keyframes modal-fadein {
+	0% { opacity: 0; }
+	100% { opacity: 1; }
+}
+
+@keyframes modal-fadeout {
+	0% { opacity: 1; }
+	100% { opacity: 0;display: none !important; }
+}
+
+#modal-overlay {
+	background-color: rgba(0, 0, 0, 0.518);
+	backdrop-filter: blur(2px);
+}
+
+#modal-box{
+	width: fit-content;
+	max-width: 60vw;
+	min-width: 300px;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background-color: orange;
+	background-image: linear-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5));
+	border-radius: calc(2 * var(--card-border-radius));
+	box-shadow: 0px 0px 4px 4px rgba(0, 0, 0, 0.318);
+	padding: 16px;
+	z-index: 1001;
+}
+
+#modal-title {
+	font-family: 'Mali', cursive;
+	font-size: 2rem;
+	text-align: center;
+	margin: 8px 0;
+}
+
+#modal-content {
+	margin: 8px 0;
+}
+
+#modal-actions {
+	display: flex;
+	justify-content: end;
+}
+
+#modal-confirm, #modal-cancel{
+	border: none;
+	background-color: white;
+	color: orange;
+	padding: 5px 15px;
+	border-radius: calc(var(--card-border-radius) / 2);
+	box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.518);
+	transition: 300ms;
+	margin: 0 8px;
+}
+
+#modal-confirm:hover, #modal-cancel:hover{
+	background-color: orange;
+	color: white;
+	box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.518);
+	cursor: pointer;
+}


### PR DESCRIPTION
This PR implements custom modal boxes instead of native `confirm()` calls, as was discussed in #47.

Here is a screen recording of it working: [Modal_ScreenGrab](https://user-images.githubusercontent.com/96870071/194698874-462c8b95-3835-4b38-8e77-5b6a25e73a46.webm)
